### PR TITLE
Moving the zoom in and zoom out buttons

### DIFF
--- a/src/js/mapi.js
+++ b/src/js/mapi.js
@@ -11,7 +11,10 @@ var Mapi = (function () {
     // leaflet access token
     const accessToken = 'pk.eyJ1IjoianlvbmdlIiwiYSI6ImNrMzFzOTJhOTAzczUzbG9iNzJkbThqNGgifQ.P8qxxnXrweFPSDAk0myObw';
 
-    var mymap = L.map('mapid').setView([30.2672, -97.7431], 13);
+   
+    var mymap = L.map('mapid',{ zoomControl: false }).setView([latMap, longMap], zoom);
+
+    new L.Control.Zoom({ position: 'bottomright'}).addTo(mymap);
 
     L.tileLayer(`https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token=${accessToken}`, {
       // attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, <a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',


### PR DESCRIPTION
This is to change how the zoom buttons are created and move them from the top left to the bottom right